### PR TITLE
issue-195-invokeText

### DIFF
--- a/gator/invoke.py
+++ b/gator/invoke.py
@@ -32,10 +32,10 @@ def invoke_commits_check(student_repository, expected_count, exact=False):
     if not exact:
         # create a message for an "at least" because it is not exact
         # the "at least" check is the default, you must opt-in to an exact check
-        message = "Repository has at least " + str(expected_count) + " commit(s)"
+        message = "The repository has at least " + str(expected_count) + " commit(s)"
     else:
         # create a message for an exact check
-        message = "Repository has exactly " + str(expected_count) + " commit(s)"
+        message = "The repository has exactly " + str(expected_count) + " commit(s)"
     # diagnostic is created when repository does not have sufficient commits
     # call report_result to update report for this check
     diagnostic = "Found " + str(actual_count) + " commit(s) in the Git repository"


### PR DESCRIPTION


<!-- A short description can be included here -->
Updated inoke.py to say "The repository has" rather than "Respository has" to match other content of checks
<!-- Please ensure that reviewers are assigned -->

### What is the current behavior?
check displays text "Repository has" which does not mach current format
<!-- You can link to an open issue here -->
https://github.com/GatorEducator/gatorgrader/issues/194
### What is the new behavior if this PR is merged?
Updated to say "The repository has" 
#### Other information

##### This PR has:

- [ ] Commit messages that are correctly formatted
- [ ] Tests for newly introduced code
- [ ] Docstrings for newly introduced code

This PR is a <!-- REQUIRED: replace this comment with one of ["small change", "feature", "compatibility breaking update", "non-versioned change"] -->
that fixes #<!-- replace this comment with an issue number if applicable -->

<!-- We required the above line statement because GatorGrader uses: -->
<!-- https://github.com/Michionlion/pr-tag-release -->
<!-- to automatically generate a tag and a release from a merged PR -->

#### Developers
Ayrton Ciancimino
@<!-- Include your name, and @ any others responsible for these changes -->
